### PR TITLE
Fix typo

### DIFF
--- a/packages/@ohp/app/src/settings/constants.js
+++ b/packages/@ohp/app/src/settings/constants.js
@@ -5,7 +5,7 @@ export const editedSuffix = '*'
 export const defaultBody = `---
 fontSize: 32
 pageNumber:
-  enable: ture
+  enable: true
   className: pageNumber
 ---
 


### PR DESCRIPTION
### WHY

I found typographical error with default value. Expected `enable: true`.

```yaml
fontSize: 32
pageNumber:
  enable: ture
  className: pageNumber
```

### WHAT

Fix typo